### PR TITLE
neovim and xdebug should be configured with localhost

### DIFF
--- a/provisioning/roles/neovim/files/init.vim
+++ b/provisioning/roles/neovim/files/init.vim
@@ -390,9 +390,11 @@ lua <<EOF
         request = 'launch',
         name = 'Listen for Xdebug',
         port = 9003,
-        host = '0.0.0.0',
+        host = 'localhost',
+-- UNCOMMENT ACCORDING TO YOUR NEED
+--        host = '0.0.0.0',
 --        pathMappings = { ['/vagrant'] = '/vagrant/'}
-        pathMappings = { ['/var/task'] = '/vagrant/'}
+--        pathMappings = { ['/var/task'] = '/vagrant/'}
 
 
       }


### PR DESCRIPTION
by default, we consider neovim and xdebug to be on the same machine; furthermore, no path mapping is required by default