### PR TITLE
upgrade devbox to php8.4 and make some changes for neovim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,16 +71,16 @@ RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php -y && \
     apt-get update && \
     apt-get install -y \
         unzip \
-        php8.2-cli \
-        php8.2-common \
-        php8.2-pgsql \
-        php8.2-curl \
-        php8.2-xml \
-        php8.2-zip \
-        php8.2-intl \
-        php8.2-bcmath \
-        php8.2-mbstring \
-        php8.2-xdebug \
+        php8.4-cli \
+        php8.4-common \
+        php8.4-pgsql \
+        php8.4-curl \
+        php8.4-xml \
+        php8.4-zip \
+        php8.4-intl \
+        php8.4-bcmath \
+        php8.4-mbstring \
+        php8.4-xdebug \
     && \
     apt-get clean && \
     # install ansible

--- a/provisioning/roles/neovim/files/init.vim
+++ b/provisioning/roles/neovim/files/init.vim
@@ -39,8 +39,6 @@ call plug#begin('~/.local/share/nvim/plugged')
 
 Plug 'nvim-neotest/nvim-nio'
 
-Plug 'folke/tokyonight.nvim', { 'branch': 'main' }
-
 Plug 'ntpeters/vim-better-whitespace'
 
 Plug 'dcampos/nvim-snippy'
@@ -65,14 +63,11 @@ Plug 'mfussenegger/nvim-dap'
 Plug 'rcarriga/nvim-dap-ui'
 Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}
 Plug 'theHamsta/nvim-dap-virtual-text'
-Plug 'codota/tabnine-nvim', { 'do': './dl_binaries.sh' }
 Plug 'andymass/vim-matchup'
 
 
 " Initialize plugin system
 call plug#end()
-
-colorscheme tokyonight
 
 " to easily switch from a split containing a terminal to an other split
 " see https://medium.com/@garoth/neovim-terminal-usecases-tricks-8961e5ac19b9
@@ -425,16 +420,6 @@ lua <<EOF
         enable = true,              -- mandatory, false will disable the whole extension
       },
     }
-
-    require('tabnine').setup({
-      disable_auto_comment=true,
-      accept_keymap="<Tab>",
-      dismiss_keymap = "<C-]>",
-      debounce_ms = 800,
-      suggestion_color = {gui = "#808080", cterm = 244},
-      exclude_filetypes = {"TelescopePrompt", "NvimTree"},
-      log_file_path = nil, -- absolute path to Tabnine log file
-    })
 EOF
 
 nnoremap <silent> <F5> :lua require('dap').toggle_breakpoint()<CR>

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,0 +1,5 @@
+zend_extension=xdebug.so
+xdebug.start_with_request=yes
+xdebug.mode=develop,debug
+xdebug.client_host=172.19.0.1
+xdebug.log=/tmp/debug.log


### PR DESCRIPTION
main change: upgrade to php8.4;

other changes:
- remove Tabnine neovim connector, as we do not use it
- remove Tokyo nvim syntax highlighting plugin, as default neovim syntax is fine,
- added the xdebug.ini file so that we can directly use it in the PHP configuration, making it easier for our PHP configuration to reach the neovim xdebug server

note that we stay on Ubuntu 22.04 LTS (Jammy) instead of upgrading to the latest LTS (Noble); in fact, the latest Ubuntu LTS would require to change a few things in the way of installing Python packages and Node (for instance, system-global Python packages are now installed through the system packages system using "apt install python-packageName" instead of globally installing them with pip3, to prevent overwritting system packages);
we do not want to handle such changes for now, as this docker image is simply a container environment, not intended to be run in production;